### PR TITLE
fix: :bug: Lift names now fitson their corresponding boxes

### DIFF
--- a/Screens/SavedLifts.js
+++ b/Screens/SavedLifts.js
@@ -253,7 +253,9 @@ export default function SavedLifts({ route, navigation }) {
                     fontSize: 20,
                     textAlign: "center",
                     width: "48%",
+                    textAlign: "left",
                   }}
+                  numberOfLines={2}
                 >
                   {lift.exerciseName}
                 </Text>

--- a/Screens/SearchLift.js
+++ b/Screens/SearchLift.js
@@ -308,13 +308,12 @@ export default function SearchLift({ navigation }) {
                 </Pressable>
                 <View
                   style={{
-                    width: "80%",
+                    width: "70%",
                     padding: 10,
                     display: "flex",
                     flexDirection: "column",
                     justifyContent: "center",
                     alignItems: "flex-start",
-                    marginLeft: 10,
                   }}
                 >
                   <Text
@@ -322,7 +321,9 @@ export default function SearchLift({ navigation }) {
                       color: "#fff",
                       fontSize: 20,
                       textAlign: "left",
+                      marginRight: 10,
                     }}
+                    numberOfLines={2}
                   >
                     {lift.exerciseName}
                   </Text>

--- a/components/EditingRoutineExerciseList.js
+++ b/components/EditingRoutineExerciseList.js
@@ -115,6 +115,8 @@ export default function EditingRoutineExerciseList({ navigation, exercices }) {
                   marginLeft: 16,
                   maxWidth: 180,
                 }}
+                numberOfLines={2}
+                ellipsizeMode="tail"
               >
                 {item.exercise.exerciseName}
               </Text>


### PR DESCRIPTION
![WhatsApp Image 2024-04-10 at 16 30 43](https://github.com/YeyoM/wellness-mobile-app/assets/76639199/b73d9f22-7499-4201-92c8-374922b00f65)
![WhatsApp Image 2024-04-10 at 16 30 40](https://github.com/YeyoM/wellness-mobile-app/assets/76639199/9531f87b-7099-4d24-bff3-296bd36b41c2)
![WhatsApp Image 2024-04-10 at 16 30 38](https://github.com/YeyoM/wellness-mobile-app/assets/76639199/9bca77f6-874a-4d2b-b451-a20cc6440c7e)
