### PR TITLE
No next lift button available #187

### DIFF
--- a/Screens/WorkoutInProgress.js
+++ b/Screens/WorkoutInProgress.js
@@ -76,7 +76,7 @@ export default function WorkoutInProgress({ route, navigation }) {
   const [isSpeedValid, setIsSpeedValid] = useState(false);
 
   const [numberOfExercises] = useState(
-    day.exercises.length + day.cardioExercises?.length,
+    day.exercises.length + (day.cardioExercises?.length ?? 0),
   );
   const [exerciseQueue, setExerciseQueue] = useState([]);
   const [currentSets, setCurrentSets] = useState();


### PR DESCRIPTION
# No next lift button available #187
On this code, replace:
```js
day.exercises.length + day.cardioExercises?.length
```
for:
```js
day.exercises.length + (day.cardioExercises?.length ?? 0)
```

Using the nullish coalescing operator (??) comparing if day.cardioExercises is or not undefined, obtain a satisfactory result.

## 🏁 Result

### Before
https://github.com/YeyoM/wellness-mobile-app/assets/78810527/6fa04f93-22e1-4003-a5b1-c9133b49989c

On this case, all excersise of cardio, get day.cardioExercises value showing button "Next excersise" but button not show on excersise for example of body.

### After
https://github.com/YeyoM/wellness-mobile-app/assets/78810527/4e18b4d2-2c0a-4f50-9cdd-daf19bc41a86

On this case, all excersise of cardio, get day.cardioExercises value showing button "Next excersise" and body excersise also show button